### PR TITLE
Brooklyn-Spark example

### DIFF
--- a/spark-demo-brooklyn/README.md
+++ b/spark-demo-brooklyn/README.md
@@ -1,0 +1,39 @@
+# Quick start
+
+## Overview
+
+
+`app.yaml` describes a cluster of [Apache Spark](https://github.com/brooklyncentral/brooklyn-spark) nodes to which Spark applications can subsequently be deployed. It uses definitions from the [brooklyn-spark](https://github.com/brooklyncentral/brooklyn-spark) project written by the [Apache Brooklyn](https://github.com/apache/brooklyn) community.
+
+## Usage
+
+To install and run Apache Brooklyn and its CLI refer to the Brooklyn
+[getting started guide](https://brooklyn.apache.org/v/latest/start/running.html).
+Once the server is running add [locations](https://brooklyn.apache.org/v/latest/start/blueprints.html#locations)
+for the clouds you want to target.
+
+Use the `br` CLI tool to add `brooklyn-spark.bom` to the catalog and then deploy `app.yaml`:
+
+```
+br catalog add https://raw.githubusercontent.com/Montlake/blueprint-illustrations/spark-demo-brooklyn/brooklyn-spark.bom
+br deploy https://raw.githubusercontent.com/Montlake/blueprint-illustrations/spark-demo-brooklyn/app.yaml
+```
+
+This will deploy the blueprint to AWS EC2 in region us-west-2.
+
+To submit a Spark application click on one of your Spark clusters, invoke the "SubmitSparkApp" effector, the output of the effector will go be displayed in the effectors activity tab.
+
+To destroy the deployment use the `stop` effector on the application.
+
+Or use the `br` CLI tool:
+
+```
+# list the applications
+br app 
+
+    Id           Name                Status    Location
+    x5jg2kaxc9   Example App         RUNNING   do2dmc7xhk
+
+# stop the app
+br app x5jg2kaxc9 stop
+```

--- a/spark-demo-brooklyn/app.yaml
+++ b/spark-demo-brooklyn/app.yaml
@@ -1,0 +1,37 @@
+# uses the brooklyn-spark node
+name: Example App
+
+location: jclouds:aws-ec2:us-west-2
+
+services:
+- type: org.apache.brooklyn.entity.stock.BasicApplication
+  id: app
+
+  brooklyn.children:
+  - type: org.apache.brooklyn.entity.group.DynamicCluster
+    description: An Apache Spark cluster
+    name: Spark Cluster
+    id: spark-cluster
+    brooklyn.config:
+      cluster.initial.size: 3
+
+    firstMemberSpec:
+      $brooklyn:entitySpec:
+        type: spark-node
+        name: Spark Master
+        id: spark-master
+        brooklyn.config:
+          # configure the spark app jars you want to submit
+          runtimeFiles:
+            http://dl.bintray.com/typesafe/maven-releases/org/apache/spark/spark-examples_2.11/1.6.0-typesafe-001/spark-examples_2.11-1.6.0-typesafe-001.jar: /tmp/spark-examples_2.11-1.6.0-typesafe-001.jar
+
+    memberSpec:
+      $brooklyn:entitySpec:
+        type: spark-node
+        name: Spark Worker
+        id: spark-worker
+        brooklyn.config:
+          spark.master.url: $brooklyn:entity("spark-master").attributeWhenReady("spark.url")
+          # configure the spark app jars you want to submit
+          runtimeFiles:
+            http://dl.bintray.com/typesafe/maven-releases/org/apache/spark/spark-examples_2.11/1.6.0-typesafe-001/spark-examples_2.11-1.6.0-typesafe-001.jar: /tmp/spark-examples_2.11-1.6.0-typesafe-001.jar

--- a/spark-demo-brooklyn/brooklyn-spark.bom
+++ b/spark-demo-brooklyn/brooklyn-spark.bom
@@ -1,0 +1,4 @@
+brooklyn.catalog:
+  items:
+    # loads the brooklyn-spark component definition
+    - https://raw.githubusercontent.com/brooklyncentral/brooklyn-spark/d5a9767ddd8d3a0b1707870b926058dc45145f50/catalog/spark/spark.bom


### PR DESCRIPTION
This PR adds an example app that deploys a cluster of [brooklyn-spark](https://github.com/brooklyncentral/brooklyn-spark) nodes and allows you to submit jobs to these spark nodes using an effector.

- added spark-demo-brooklyn directory
- added README
- added app.yaml
- added brooklyn-spark.bom