### PR TITLE
firewalld: handle if not available

### DIFF
--- a/three-tier-nodejs-brooklyn/mariadb.bom
+++ b/three-tier-nodejs-brooklyn/mariadb.bom
@@ -33,8 +33,7 @@ brooklyn.catalog:
           MARIADB_DATASTORE_CREATION_SCRIPT_URL: $brooklyn:config("mariadb.datastore.creation.script.url")
 
         pre.install.command: |
-          sudo systemctl stop firewalld
-          sudo systemctl disable firewalld
+          (sudo systemctl stop firewalld && sudo systemctl disable firewalld) || echo "Could not disable firewalld"
           sudo yum update -y
 
         install.command: |

--- a/three-tier-nodejs-brooklyn/nodejs.bom
+++ b/three-tier-nodejs-brooklyn/nodejs.bom
@@ -46,8 +46,7 @@ brooklyn.catalog:
           SERVER_PORT: $brooklyn:attributeWhenReady("http.port")
 
         pre.install.command: |
-          sudo systemctl stop firewalld
-          sudo systemctl disable firewalld
+          (sudo systemctl stop firewalld && sudo systemctl disable firewalld) || echo "Could not disable firewalld"
           sudo yum update -y
 
         install.command: |


### PR DESCRIPTION
On some CentOS VMs in AWS (e.g. `eu-west-1/ami-061b1560`) firewalld is not running, so the `pre.install.command` failed.